### PR TITLE
Update the seeder mechanism to write data out in chunks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,5 @@
+language: node_js
+node_js:
+  - "4"
+  - "6"
+  - "node"

--- a/dynamodb/migrations.js
+++ b/dynamodb/migrations.js
@@ -1,7 +1,11 @@
 'use strict';
 
+const MAX_MIGRATION_CHUNK = 25;
+const MIGRATION_SEED_CONCURRENCY = 5;
+
 var BbPromise = require('bluebird'),
     fs = require('fs'),
+    _ = require('lodash'),
     path = require('path');
 
 var createTable = function(dynamodb, migration) {
@@ -21,44 +25,59 @@ var formatTableName = function(migration, options) {
     return options.tablePrefix + migration.Table.TableName + options.tableSuffix;
 };
 
+/**
+ * Writes a batch chunk of migration seeds to DynamoDB. DynamoDB has a limit on the number of
+ * items that may be written in a batch operation.
+ * @param {string} tableName The table name being written to
+ * @param {any[]} seeds The migration seeds being written to the table
+ */
+var writeSeedBatch = function(dynamodb, tableName, seeds) {
+    var params,
+        batchSeeds = seeds.map(function(seed) {
+            return {
+                PutRequest: {
+                    Item: seed
+                }
+            };
+        });
+    params = {
+        RequestItems: {}
+    };
+    params.RequestItems[tableName] = batchSeeds;
+    return new BbPromise((resolve, reject) => {
+        var interval = 0,
+            execute = function(interval) {
+                setTimeout(function() {
+                    dynamodb.doc.batchWrite(params, function(err) {
+                        if (err) {
+                            if (err.code === "ResourceNotFoundException" && interval <= 5000) {
+                                execute(interval + 1000);
+                            } else {
+                                reject(err);
+                            }
+                        } else {
+                            resolve();
+                        }
+                    });
+                }, interval);
+            };
+        execute(interval);
+    });
+}
+
 var runSeeds = function(dynamodb, migration) {
     if (!migration.Seeds || !migration.Seeds.length) {
         return new BbPromise(function(resolve) {
             resolve(migration);
         });
     } else {
-        var params,
-            batchSeeds = migration.Seeds.map(function(seed) {
-                return {
-                    PutRequest: {
-                        Item: seed
-                    }
-                };
-            });
-        params = {
-            RequestItems: {}
-        };
-        params.RequestItems[migration.Table.TableName] = batchSeeds;
-        return new BbPromise(function(resolve, reject) {
-            var interval = 0,
-                execute = function(interval) {
-                    setTimeout(function() {
-                        dynamodb.doc.batchWrite(params, function(err) {
-                            if (err) {
-                                if (err.code === "ResourceNotFoundException" && interval <= 5000) {
-                                    execute(interval + 1000);
-                                } else {
-                                    reject(err);
-                                }
-                            } else {
-                                console.log("Seed running complete for table: " + migration.Table.TableName);
-                                resolve(migration);
-                            }
-                        });
-                    }, interval);
-                };
-            execute(interval);
-        });
+        var seedChunks = _.chunk(migration.Seeds, MAX_MIGRATION_CHUNK);
+        return BbPromise.map(
+            seedChunks,
+            chunk => writeSeedBatch(dynamodb, migration.Table.TableName, chunk),
+            { concurrency: MIGRATION_SEED_CONCURRENCY }
+        )
+        .then(() => console.log("Seed running complete for table: " + migration.Table.TableName));
     }
 };
 

--- a/dynamodb/migrations.js
+++ b/dynamodb/migrations.js
@@ -63,7 +63,7 @@ var writeSeedBatch = function(dynamodb, tableName, seeds) {
             };
         execute(interval);
     });
-}
+};
 
 var runSeeds = function(dynamodb, migration) {
     if (!migration.Seeds || !migration.Seeds.length) {

--- a/package.json
+++ b/package.json
@@ -11,6 +11,9 @@
     "type": "git",
     "url": "https://github.com/99xt/dynamodb-migrations"
   },
+  "scripts": {
+    "test": "jshint dynamodb"
+  },
   "keywords": [
     "aws",
     "dynamodb",

--- a/package.json
+++ b/package.json
@@ -32,5 +32,8 @@
     "bluebird": "^3.0.6",
     "lodash": "^4.17.4",
     "mkdirp": "^0.5.0"
+  },
+  "devDependencies": {
+    "jshint": "^2.9.4"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,17 +1,17 @@
 {
-    "name": "dynamodb-migrations",
-    "version": "0.0.10",
-    "engines": {
-        "node": ">=4.0"
-    },
-    "description": "Dynamodb migrations for devops",
-    "author": "99xtechnology.com",
-    "license": "MIT",
-    "repository": {
-        "type": "git",
-        "url": "https://github.com/99xt/dynamodb-migrations"
-    },
-    "keywords": [
+  "name": "dynamodb-migrations",
+  "version": "0.0.10",
+  "engines": {
+    "node": ">=4.0"
+  },
+  "description": "Dynamodb migrations for devops",
+  "author": "99xtechnology.com",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/99xt/dynamodb-migrations"
+  },
+  "keywords": [
     "aws",
     "dynamodb",
     "dynamo",
@@ -23,10 +23,11 @@
     "local-dynamodb",
     "dynamodb-local"
   ],
-    "main": "index.js",
-    "bin": {},
-    "dependencies": {
-        "mkdirp": "^0.5.0",
-        "bluebird": "^3.0.6"
-    }
+  "main": "index.js",
+  "bin": {},
+  "dependencies": {
+    "bluebird": "^3.0.6",
+    "lodash": "^4.17.4",
+    "mkdirp": "^0.5.0"
+  }
 }


### PR DESCRIPTION
I'm running into some data limits on writing data to Dynamo. According to their documentation at https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_BatchWriteItem.html, I believe it's one of the following:

```
If one or more of the following is true, DynamoDB rejects the entire batch write operation:
...
There are more than 25 requests in the batch.
The total request size exceeds 16 MB.
```

This commit uses a chunk-and-parallelize approach to handle loading of seeding sets. First, the seeding items are chunked into batches of 25 (via lodash.chunk), then we use Bluebird's `Promise.map` to write these to the database with 5 batches being written in parallel.

Fixes #5 