### PR TITLE
Simple log message when table exists

### DIFF
--- a/dynamodb/migrations.js
+++ b/dynamodb/migrations.js
@@ -8,7 +8,11 @@ var createTable = function(dynamodb, migration) {
     return new BbPromise(function(resolve) {
         dynamodb.raw.createTable(migration.Table, function(err) {
             if (err) {
-                console.log(err);
+                if (err.message.split(":")[0] === "Table already exists") {
+                    console.log(err.message);
+                } else {
+                    console.log(err);
+                }
             } else {
                 console.log("Table creation completed for table: " + migration.Table.TableName);
             }


### PR DESCRIPTION
Right now if table creation fails the error is simply logged out as is, the whole stack. It is ugly. At least for the scenario where table already exist we can simply log the error message.

Below is how it currently looks;
```
{ ResourceInUseException: Table already exists: dev_Teams
    at Request.extractError (/home/afzal/datacoral/datasources/services/proxy-service/node_modules/aws-sdk/lib/protocol/json.js:48:27)
    at Request.callListeners (/home/afzal/datacoral/datasources/services/proxy-service/node_modules/aws-sdk/lib/sequential_executor.js:105:20)
    at Request.emit (/home/afzal/datacoral/datasources/services/proxy-service/node_modules/aws-sdk/lib/sequential_executor.js:77:10)
    at Request.emit (/home/afzal/datacoral/datasources/services/proxy-service/node_modules/aws-sdk/lib/request.js:683:14)
    at Request.transition (/home/afzal/datacoral/datasources/services/proxy-service/node_modules/aws-sdk/lib/request.js:22:10)
    at AcceptorStateMachine.runTo (/home/afzal/datacoral/datasources/services/proxy-service/node_modules/aws-sdk/lib/state_machine.js:14:12)
    at /home/afzal/datacoral/datasources/services/proxy-service/node_modules/aws-sdk/lib/state_machine.js:26:10
    at Request.<anonymous> (/home/afzal/datacoral/datasources/services/proxy-service/node_modules/aws-sdk/lib/request.js:38:9)
    at Request.<anonymous> (/home/afzal/datacoral/datasources/services/proxy-service/node_modules/aws-sdk/lib/request.js:685:12)
    at Request.callListeners (/home/afzal/datacoral/datasources/services/proxy-service/node_modules/aws-sdk/lib/sequential_executor.js:115:18)
    at Request.emit (/home/afzal/datacoral/datasources/services/proxy-service/node_modules/aws-sdk/lib/sequential_executor.js:77:10)
    at Request.emit (/home/afzal/datacoral/datasources/services/proxy-service/node_modules/aws-sdk/lib/request.js:683:14)
    at Request.transition (/home/afzal/datacoral/datasources/services/proxy-service/node_modules/aws-sdk/lib/request.js:22:10)
    at AcceptorStateMachine.runTo (/home/afzal/datacoral/datasources/services/proxy-service/node_modules/aws-sdk/lib/state_machine.js:14:12)
    at /home/afzal/datacoral/datasources/services/proxy-service/node_modules/aws-sdk/lib/state_machine.js:26:10
    at Request.<anonymous> (/home/afzal/datacoral/datasources/services/proxy-service/node_modules/aws-sdk/lib/request.js:38:9)
  message: 'Table already exists: dev_Teams',
  code: 'ResourceInUseException',
  time: 2017-08-17T17:21:40.366Z,
  requestId: 'GSMFC0C45TD7CAORUPQP1MD5Q3VV4KQNSO5AEMVJF66Q9ASUAAJG',
  statusCode: 400,
  retryable: false,
  retryDelay: 41.210013426674294 }
{ ResourceInUseException: Table already exists: dev_Users
    at Request.extractError (/home/afzal/datacoral/datasources/services/proxy-service/node_modules/aws-sdk/lib/protocol/json.js:48:27)
    at Request.callListeners (/home/afzal/datacoral/datasources/services/proxy-service/node_modules/aws-sdk/lib/sequential_executor.js:105:20)
    at Request.emit (/home/afzal/datacoral/datasources/services/proxy-service/node_modules/aws-sdk/lib/sequential_executor.js:77:10)
    at Request.emit (/home/afzal/datacoral/datasources/services/proxy-service/node_modules/aws-sdk/lib/request.js:683:14)
    at Request.transition (/home/afzal/datacoral/datasources/services/proxy-service/node_modules/aws-sdk/lib/request.js:22:10)
    at AcceptorStateMachine.runTo (/home/afzal/datacoral/datasources/services/proxy-service/node_modules/aws-sdk/lib/state_machine.js:14:12)
    at /home/afzal/datacoral/datasources/services/proxy-service/node_modules/aws-sdk/lib/state_machine.js:26:10
    at Request.<anonymous> (/home/afzal/datacoral/datasources/services/proxy-service/node_modules/aws-sdk/lib/request.js:38:9)
    at Request.<anonymous> (/home/afzal/datacoral/datasources/services/proxy-service/node_modules/aws-sdk/lib/request.js:685:12)
    at Request.callListeners (/home/afzal/datacoral/datasources/services/proxy-service/node_modules/aws-sdk/lib/sequential_executor.js:115:18)
    at Request.emit (/home/afzal/datacoral/datasources/services/proxy-service/node_modules/aws-sdk/lib/sequential_executor.js:77:10)
    at Request.emit (/home/afzal/datacoral/datasources/services/proxy-service/node_modules/aws-sdk/lib/request.js:683:14)
    at Request.transition (/home/afzal/datacoral/datasources/services/proxy-service/node_modules/aws-sdk/lib/request.js:22:10)
    at AcceptorStateMachine.runTo (/home/afzal/datacoral/datasources/services/proxy-service/node_modules/aws-sdk/lib/state_machine.js:14:12)
    at /home/afzal/datacoral/datasources/services/proxy-service/node_modules/aws-sdk/lib/state_machine.js:26:10
    at Request.<anonymous> (/home/afzal/datacoral/datasources/services/proxy-service/node_modules/aws-sdk/lib/request.js:38:9)
  message: 'Table already exists: dev_Users',
  code: 'ResourceInUseException',
  time: 2017-08-17T17:21:40.382Z,
  requestId: 'T7D17SMH6KQPFU50GP06GSP2QBVV4KQNSO5AEMVJF66Q9ASUAAJG',
  statusCode: 400,
  retryable: false,
  retryDelay: 35.89444793078186 }
{ ResourceInUseException: Table already exists: dev_Slice_Categories
    at Request.extractError (/home/afzal/datacoral/datasources/services/proxy-service/node_modules/aws-sdk/lib/protocol/json.js:48:27)
    at Request.callListeners (/home/afzal/datacoral/datasources/services/proxy-service/node_modules/aws-sdk/lib/sequential_executor.js:105:20)
    at Request.emit (/home/afzal/datacoral/datasources/services/proxy-service/node_modules/aws-sdk/lib/sequential_executor.js:77:10)
    at Request.emit (/home/afzal/datacoral/datasources/services/proxy-service/node_modules/aws-sdk/lib/request.js:683:14)
    at Request.transition (/home/afzal/datacoral/datasources/services/proxy-service/node_modules/aws-sdk/lib/request.js:22:10)
    at AcceptorStateMachine.runTo (/home/afzal/datacoral/datasources/services/proxy-service/node_modules/aws-sdk/lib/state_machine.js:14:12)
    at /home/afzal/datacoral/datasources/services/proxy-service/node_modules/aws-sdk/lib/state_machine.js:26:10
    at Request.<anonymous> (/home/afzal/datacoral/datasources/services/proxy-service/node_modules/aws-sdk/lib/request.js:38:9)
    at Request.<anonymous> (/home/afzal/datacoral/datasources/services/proxy-service/node_modules/aws-sdk/lib/request.js:685:12)
    at Request.callListeners (/home/afzal/datacoral/datasources/services/proxy-service/node_modules/aws-sdk/lib/sequential_executor.js:115:18)
    at Request.emit (/home/afzal/datacoral/datasources/services/proxy-service/node_modules/aws-sdk/lib/sequential_executor.js:77:10)
    at Request.emit (/home/afzal/datacoral/datasources/services/proxy-service/node_modules/aws-sdk/lib/request.js:683:14)
    at Request.transition (/home/afzal/datacoral/datasources/services/proxy-service/node_modules/aws-sdk/lib/request.js:22:10)
    at AcceptorStateMachine.runTo (/home/afzal/datacoral/datasources/services/proxy-service/node_modules/aws-sdk/lib/state_machine.js:14:12)
    at /home/afzal/datacoral/datasources/services/proxy-service/node_modules/aws-sdk/lib/state_machine.js:26:10
    at Request.<anonymous> (/home/afzal/datacoral/datasources/services/proxy-service/node_modules/aws-sdk/lib/request.js:38:9)
  message: 'Table already exists: dev_Slice_Categories',
  code: 'ResourceInUseException',
  time: 2017-08-17T17:21:40.408Z,
  requestId: 'V40L1K518BVK25M6LP6S8702HVVV4KQNSO5AEMVJF66Q9ASUAAJG',
  statusCode: 400,
  retryable: false,
  retryDelay: 7.4013873251306705 }
{ ResourceInUseException: Table already exists: dev_Slice_Types
    at Request.extractError (/home/afzal/datacoral/datasources/services/proxy-service/node_modules/aws-sdk/lib/protocol/json.js:48:27)
    at Request.callListeners (/home/afzal/datacoral/datasources/services/proxy-service/node_modules/aws-sdk/lib/sequential_executor.js:105:20)
    at Request.emit (/home/afzal/datacoral/datasources/services/proxy-service/node_modules/aws-sdk/lib/sequential_executor.js:77:10)
    at Request.emit (/home/afzal/datacoral/datasources/services/proxy-service/node_modules/aws-sdk/lib/request.js:683:14)
    at Request.transition (/home/afzal/datacoral/datasources/services/proxy-service/node_modules/aws-sdk/lib/request.js:22:10)
    at AcceptorStateMachine.runTo (/home/afzal/datacoral/datasources/services/proxy-service/node_modules/aws-sdk/lib/state_machine.js:14:12)
    at /home/afzal/datacoral/datasources/services/proxy-service/node_modules/aws-sdk/lib/state_machine.js:26:10
    at Request.<anonymous> (/home/afzal/datacoral/datasources/services/proxy-service/node_modules/aws-sdk/lib/request.js:38:9)
    at Request.<anonymous> (/home/afzal/datacoral/datasources/services/proxy-service/node_modules/aws-sdk/lib/request.js:685:12)
    at Request.callListeners (/home/afzal/datacoral/datasources/services/proxy-service/node_modules/aws-sdk/lib/sequential_executor.js:115:18)
    at Request.emit (/home/afzal/datacoral/datasources/services/proxy-service/node_modules/aws-sdk/lib/sequential_executor.js:77:10)
    at Request.emit (/home/afzal/datacoral/datasources/services/proxy-service/node_modules/aws-sdk/lib/request.js:683:14)
    at Request.transition (/home/afzal/datacoral/datasources/services/proxy-service/node_modules/aws-sdk/lib/request.js:22:10)
    at AcceptorStateMachine.runTo (/home/afzal/datacoral/datasources/services/proxy-service/node_modules/aws-sdk/lib/state_machine.js:14:12)
    at /home/afzal/datacoral/datasources/services/proxy-service/node_modules/aws-sdk/lib/state_machine.js:26:10
    at Request.<anonymous> (/home/afzal/datacoral/datasources/services/proxy-service/node_modules/aws-sdk/lib/request.js:38:9)
  message: 'Table already exists: dev_Slice_Types',
  code: 'ResourceInUseException',
  time: 2017-08-17T17:21:40.439Z,
  requestId: 'UMRVDGD9P20BDIBAIKUBB2069VVV4KQNSO5AEMVJF66Q9ASUAAJG',
  statusCode: 400,
  retryable: false,
  retryDelay: 42.237072576040546 }
{ ResourceInUseException: Table already exists: dev_AWS_Accounts
    at Request.extractError (/home/afzal/datacoral/datasources/services/proxy-service/node_modules/aws-sdk/lib/protocol/json.js:48:27)
    at Request.callListeners (/home/afzal/datacoral/datasources/services/proxy-service/node_modules/aws-sdk/lib/sequential_executor.js:105:20)
    at Request.emit (/home/afzal/datacoral/datasources/services/proxy-service/node_modules/aws-sdk/lib/sequential_executor.js:77:10)
    at Request.emit (/home/afzal/datacoral/datasources/services/proxy-service/node_modules/aws-sdk/lib/request.js:683:14)
    at Request.transition (/home/afzal/datacoral/datasources/services/proxy-service/node_modules/aws-sdk/lib/request.js:22:10)
    at AcceptorStateMachine.runTo (/home/afzal/datacoral/datasources/services/proxy-service/node_modules/aws-sdk/lib/state_machine.js:14:12)
    at /home/afzal/datacoral/datasources/services/proxy-service/node_modules/aws-sdk/lib/state_machine.js:26:10
    at Request.<anonymous> (/home/afzal/datacoral/datasources/services/proxy-service/node_modules/aws-sdk/lib/request.js:38:9)
    at Request.<anonymous> (/home/afzal/datacoral/datasources/services/proxy-service/node_modules/aws-sdk/lib/request.js:685:12)
    at Request.callListeners (/home/afzal/datacoral/datasources/services/proxy-service/node_modules/aws-sdk/lib/sequential_executor.js:115:18)
    at Request.emit (/home/afzal/datacoral/datasources/services/proxy-service/node_modules/aws-sdk/lib/sequential_executor.js:77:10)
    at Request.emit (/home/afzal/datacoral/datasources/services/proxy-service/node_modules/aws-sdk/lib/request.js:683:14)
    at Request.transition (/home/afzal/datacoral/datasources/services/proxy-service/node_modules/aws-sdk/lib/request.js:22:10)
    at AcceptorStateMachine.runTo (/home/afzal/datacoral/datasources/services/proxy-service/node_modules/aws-sdk/lib/state_machine.js:14:12)
    at /home/afzal/datacoral/datasources/services/proxy-service/node_modules/aws-sdk/lib/state_machine.js:26:10
    at Request.<anonymous> (/home/afzal/datacoral/datasources/services/proxy-service/node_modules/aws-sdk/lib/request.js:38:9)
  message: 'Table already exists: dev_AWS_Accounts',
  code: 'ResourceInUseException',
  time: 2017-08-17T17:21:40.477Z,
  requestId: '9NKOVEVA109OAGPKPJATV7O523VV4KQNSO5AEMVJF66Q9ASUAAJG',
  statusCode: 400,
  retryable: false,
  retryDelay: 27.33116660123939 }
```

How it looks with this change applies;
```
Table already exists: dev_Slice_Types
Table already exists: dev_Teams
Table already exists: dev_Slice_Categories
Table already exists: dev_Users
Table already exists: dev_AWS_Accounts
```

I think other errors should be thrown instead of being ignored but that could be done in another commit.